### PR TITLE
Nvim-treesitter: rename `help` to `vimdoc`

### DIFF
--- a/nvim/nvim/lua/plugins/treesitter.lua
+++ b/nvim/nvim/lua/plugins/treesitter.lua
@@ -15,7 +15,7 @@ return {
                "html",
                "css",
                "comment",
-               "help",
+               "vimdoc",
                "tsx",
             },
             highlight = { enable = true },


### PR DESCRIPTION
#2
Rename `help` to `vimdoc` according to [nvim-treesitter/nvim-treesitter@93fa5df](https://github.com/nvim-treesitter/nvim-treesitter/commit/93fa5df0a3f0aeb72df50a9d2110cb90fc5a0a13)